### PR TITLE
modify API

### DIFF
--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::ApiController < ApplicationController
-  def current_user
-    current_user = User.first
-  end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :set_article, only: [:update, :destroy]
+  before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
     articles = Article.all

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -44,14 +44,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    subject { post(api_v1_articles_path, params: params) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "current_userに紐づけられた記事を作成できる" do
       expect { subject }.to change { current_user.articles.count }.by(1)
@@ -60,15 +57,12 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: { title: Faker::Lorem.characters(number: Random.new.rand(1..50)), created_at: Time.current } } }
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token}
 
     it "current_userに紐づけられた記事を更新できる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
@@ -79,14 +73,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article.id)) }
-
-    before do
-      allow_any_instance_of(Api::V1::ApiController).to receive(:current_user).and_return(current_user)
-    end
+    subject { delete(api_v1_article_path(article.id), headers: headers) }
 
     let!(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     it "current_userに紐づけられた記事を削除できる" do
       expect { subject }.to change { current_user.articles.count }.by(-1)

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let(:params) { { article: { title: Faker::Lorem.characters(number: Random.new.rand(1..50)), created_at: Time.current } } }
     let(:article) { create(:article, user: current_user) }
     let(:current_user) { create(:user) }
-    let(:headers) { current_user.create_new_auth_token}
+    let(:headers) { current_user.create_new_auth_token }
 
     it "current_userに紐づけられた記事を更新できる" do
       expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &


### PR DESCRIPTION
## 概要
既存のAPIを修正

### 作業内容
- api_controller のダミーコードである current_user メソッド を削除する。
- api_controller で current_user, authenticate_user!, user_signed_in? の３つを使えるようにする。
- ログインしていないと使えない API は authenticate_user! で弾くようにする。
- テストでログインが必要な API を叩く際に headers を渡すようにする。