### PR TITLE
Implement Article draft function

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -2,6 +2,8 @@ class Article < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
   belongs_to :user
+  enum status: { draft: 0, published: 1, deleted: 2 }
   validates :title, presence: true, length: { maximum: 50 }
   validates :body, presence: true
+  validates :status, inclusion: { in: Article.statuses.keys }
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -46,6 +46,7 @@ RSpec/InstanceVariable:
 # 読みやすいテストになりやすいので、そこはレビューで担保していく必要がある。
 RSpec/MultipleExpectations:
   AggregateFailuresByDefault: true
+  Enabled: false
 
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。

--- a/db/migrate/20200420121758_add_status_to_article.rb
+++ b/db/migrate/20200420121758_add_status_to_article.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_05_134634) do
+ActiveRecord::Schema.define(version: 2020_04_20_121758) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
@@ -27,6 +27,7 @@ ActiveRecord::Schema.define(version: 2020_03_05_134634) do
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["user_id"], name: "index_articles_on_user_id"
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -4,8 +4,17 @@ RSpec.describe Article, type: :model do
   describe "正常系テスト" do
     context "title, body が入力されている" do
       let(:article) { build(:article) }
-      it "記事が作られる" do
+      it "記事（ステータス：下書き）が作られる" do
         expect(article.valid?).to eq true
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "title, bodyが入力されている & ステータスが公開" do
+      let(:article) { build(:article, status: "published") }
+      it "記事（ステータス：公開）が作られる" do
+        expect(article.valid?).to eq true
+        expect(article.status).to eq "published"
       end
     end
   end


### PR DESCRIPTION
## 概要
記事の下書き機能を実装

### 作業内容
- Articleテーブルにstatusカラムを追加
- article.rbにenumについて追記
- Articleの下書きに関するテストを作成
- (rubocopの設定を変更)
- rubocop -aを実行

### 参考
https://qiita.com/masahisa/items/b1fe37238399457c6610
