### PR TITLE
Modify existing API for draft function

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -34,6 +34,6 @@ class Api::V1::ArticlesController < Api::V1::ApiController
     end
 
     def article_params
-      params.require(:article).permit(:title, :body)
+      params.require(:article).permit(:title, :body, :status)
     end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.where(status: "published")
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.where(status: "published").find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.where(status: "published")
     render json: articles
   end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::ArticlesController < Api::V1::ApiController
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.where(status: "published").find(params[:id])
     render json: article
   end
 

--- a/app/serializers/article_serializer.rb
+++ b/app/serializers/article_serializer.rb
@@ -1,4 +1,4 @@
 class ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
   belongs_to :user
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :article do
     title { Faker::Lorem.characters(number: Random.new.rand(1..50)) }
     body { Faker::Lorem.paragraph }
+    status { "published" }
     user
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Article, type: :model do
   describe "正常系テスト" do
     context "title, body が入力されている" do
-      let(:article) { build(:article) }
+      let(:article) { build(:article, status: "draft") }
       it "記事（ステータス：下書き）が作られる" do
         expect(article.valid?).to eq true
         expect(article.status).to eq "draft"

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定したidの記事が存在する場合" do
+    context "指定したidの記事（ステータスが公開）が存在する場合" do
       let(:article) { create(:article) }
       let(:article_id) { article.id }
 
@@ -32,12 +32,22 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
         expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "published"
         expect(response).to have_http_status(:ok)
       end
     end
 
     context "指定したidの記事が存在しない場合" do
       let(:article_id) { 11111 }
+
+      it "記事を取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "指定したidの記事のステータスが下書きである場合" do
+      let(:article) { create(:article, status: "draft") }
+      let(:article_id) { article.id }
 
       it "記事を取得できない" do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound

--- a/spec/requests/articles_spec.rb
+++ b/spec/requests/articles_spec.rb
@@ -6,13 +6,14 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
     before do
       create_list(:article, 3)
+      create_list(:article, 5, status: "draft")
     end
 
-    it "記事一覧を取得できる" do
+    it "記事一覧（ステータスが公開）を取得できる" do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 3
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "user"]
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 概要
- 公開されている記事だけ取得できるようにする
- 記事を作成する場合は、記事の公開/非公開を選択できるようにする

### 作業内容
- APIをたたいたときに、status（公開/下書き）をJSONで渡せるように修正
- create actionでstatusを取得できるように、article_params（ストロングパラメーター）を修正
- 公開されている記事一覧を取得できるように、index actionを修正
- 公開されている記事詳細を取得できるように、show actionを修正
- 上記に関するテストを実装