### PR TITLE
Get draft articles / detail of draft article

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::Articles::DraftsController < Api::V1::ApiController
+  before_action :authenticate_user!, only: [:index, :show]
+
+  def index
+    articles = current_user.articles.draft
+    render json: articles
+  end
+
+  def show
+    article = current_user.articles.draft.find(params[:id])
+    render json: article
+  end
+end

--- a/app/serializers/draft_serializer.rb
+++ b/app/serializers/draft_serializer.rb
@@ -1,0 +1,4 @@
+class DraftSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :updated_at, :status
+  belongs_to :user
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,9 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+      namespace "articles" do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles::Drafts", type: :request do
+  describe "GET /api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let!(:drafts) { create_list(:article, 3, user: current_user, status: "draft") }
+    let!(:articles) { create_list(:article, 5, user: current_user, status: "published") }
+    let!(:drafts_by_other_user) { create_list(:article, 7, user: other_user, status: "draft") }
+    let!(:drafts_by_other_user) { create_list(:article, 9, user: other_user, status: "published") }
+    let(:current_user) { create(:user) }
+    let(:other_user) {create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    it "自分の下書き記事一覧を取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 3
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -4,12 +4,15 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
   describe "GET /api/v1/articles/drafts" do
     subject { get(api_v1_articles_drafts_path, headers: headers) }
 
-    let!(:drafts) { create_list(:article, 3, user: current_user, status: "draft") }
-    let!(:articles) { create_list(:article, 5, user: current_user, status: "published") }
-    let!(:drafts_by_other_user) { create_list(:article, 7, user: other_user, status: "draft") }
-    let!(:drafts_by_other_user) { create_list(:article, 9, user: other_user, status: "published") }
+    before do
+      create_list(:article, 3, user: current_user, status: "draft")
+      create_list(:article, 5, user: current_user, status: "published")
+      create_list(:article, 7, user: other_user, status: "draft")
+      create_list(:article, 9, user: other_user, status: "published")
+    end
+
     let(:current_user) { create(:user) }
-    let(:other_user) {create(:user) }
+    let(:other_user) { create(:user) }
     let(:headers) { current_user.create_new_auth_token }
 
     it "自分の下書き記事一覧を取得できる" do
@@ -23,8 +26,9 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
 
   describe "GET /api/v1/articles/drafts:id" do
     subject { get(api_v1_articles_draft_path(article.id), headers: headers) }
+
     let(:current_user) { create(:user) }
-    let(:other_user) {create(:user) }
+    let(:other_user) { create(:user) }
 
     context "ログインユーザーが、自分の下書き記事詳細を取得する場合" do
       let(:article) { create(:article, user: current_user, status: "draft") }

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     end
   end
 
-  describe "GET /api/v1/articles/drafts:id" do
+  describe "GET /api/v1/articles/drafts/:id" do
     subject { get(api_v1_articles_draft_path(article.id), headers: headers) }
 
     let(:current_user) { create(:user) }

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -20,4 +20,43 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  describe "GET /api/v1/articles/drafts:id" do
+    subject { get(api_v1_articles_draft_path(article.id), headers: headers) }
+    let(:current_user) { create(:user) }
+    let(:other_user) {create(:user) }
+
+    context "ログインユーザーが、自分の下書き記事詳細を取得する場合" do
+      let(:article) { create(:article, user: current_user, status: "draft") }
+      let(:headers) { current_user.create_new_auth_token }
+
+      it "取得できる" do
+        subject
+        res = JSON.parse(response.body)
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["updated_at"]).to be_present
+        expect(res["status"]).to eq "draft"
+      end
+    end
+
+    context "ログインユーザーが、他のユーザーの下書き記事詳細を取得する場合" do
+      let(:article) { create(:article, user: other_user, status: "draft") }
+      let(:headers) { current_user.create_new_auth_token }
+
+      it "取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "他のユーザーが、ログインユーザーの下書き記事詳細を取得する場合" do
+      let(:article) { create(:article, user: current_user, status: "draft") }
+      let(:headers) { other_user.create_new_auth_token }
+
+      it "取得できない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
自分が書いた下書き記事の一覧と詳細を取得できるようにする。

### 作業内容
- drafts_controllerを作成
- drafts_controllerのactionを利用できるようにroutingを変更
- JSONでデータを出力できるようにdrafts_serializerを作成
- index, show actionを実装
- 各actionのテストを実装