### PR TITLE
Get published articles on my page

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Current::ArticlesController < Api::V1::ApiController
+  before_action :authenticate_user!, only: [:index]
+
+  def index
+    articles = current_user.articles.published
+    render json: articles
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
       namespace "articles" do
         resources :drafts, only: [:index, :show]
       end
+      namespace "current" do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -4,5 +4,13 @@ FactoryBot.define do
     body { Faker::Lorem.paragraph }
     status { "published" }
     user
+
+    trait :draft do
+      status { :draft }
+    end
+
+    trait :published do
+      status { :published }
+    end
   end
 end

--- a/spec/requests/api/v1/articles/drafts_spec.rb
+++ b/spec/requests/api/v1/articles/drafts_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     subject { get(api_v1_articles_drafts_path, headers: headers) }
 
     before do
-      create_list(:article, 3, user: current_user, status: "draft")
-      create_list(:article, 5, user: current_user, status: "published")
-      create_list(:article, 7, user: other_user, status: "draft")
-      create_list(:article, 9, user: other_user, status: "published")
+      create_list(:article, 1, :draft, user: current_user)
+      create_list(:article, 2, :published, user: current_user)
+      create_list(:article, 4, :draft, user: other_user)
+      create_list(:article, 8, :published, user: other_user)
     end
 
     let(:current_user) { create(:user) }
@@ -18,7 +18,7 @@ RSpec.describe "Api::V1::Articles::Drafts", type: :request do
     it "自分の下書き記事一覧を取得できる" do
       subject
       res = JSON.parse(response.body)
-      expect(res.length).to eq 3
+      expect(res.length).to eq 1
       expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(response).to have_http_status(:ok)
     end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    before do
+      create_list(:article, 3, user: current_user, status: "draft")
+      create_list(:article, 5, user: current_user, status: "published")
+      create_list(:article, 7, user: other_user, status: "draft")
+      create_list(:article, 9, user: other_user, status: "published")
+    end
+
+    let(:current_user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:headers) { current_user.create_new_auth_token }
+
+    it "記事一覧（ステータスが公開）を取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(res.length).to eq 5
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -5,10 +5,10 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
     subject { get(api_v1_current_articles_path, headers: headers) }
 
     before do
-      create_list(:article, 3, user: current_user, status: "draft")
-      create_list(:article, 5, user: current_user, status: "published")
-      create_list(:article, 7, user: other_user, status: "draft")
-      create_list(:article, 9, user: other_user, status: "published")
+      create_list(:article, 1, :draft, user: current_user)
+      create_list(:article, 2, :published, user: current_user)
+      create_list(:article, 4, :draft, user: other_user)
+      create_list(:article, 8, :published, user: other_user)
     end
 
     let(:current_user) { create(:user) }
@@ -18,7 +18,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
     it "記事一覧（ステータスが公開）を取得できる" do
       subject
       res = JSON.parse(response.body)
-      expect(res.length).to eq 5
+      expect(res.length).to eq 2
       expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
       expect(response).to have_http_status(:ok)
     end


### PR DESCRIPTION
## 概要
マイページで自分が書いた公開記事の一覧を取得できるようにする
（endpointは、` /api/v1/current/articles`）

### 作業内容
- current/articles_controllerを作成
- 上記controllerを利用できるように、routingを修正
- テストを実装