### PR TITLE
Add my page

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -2,7 +2,7 @@ class Api::V1::Current::ArticlesController < Api::V1::ApiController
   before_action :authenticate_user!, only: [:index]
 
   def index
-    articles = current_user.articles.published
-    render json: articles
+    articles = current_user.articles.published.order(created_at: :desc)
+    render json: articles, each_serializer: Api::V1::Current::ArticlePreviewSerializer
   end
 end

--- a/app/javascript/packs/container/ArticleContainer.vue
+++ b/app/javascript/packs/container/ArticleContainer.vue
@@ -4,15 +4,8 @@
       <span class="user-name">@{{ article.user.name }}</span>
       <time-ago :refresh="60" :datetime="article.updated_at" locale="en" tooltip="top" long></time-ago>
       <v-spacer></v-spacer>
-      <v-btn
-        fab
-        flat
-        dark
-        small
-        color="#55c500"
-        @click="moveToEditArticlePage(article.id)"
-        v-if="editable"
-      >
+      <v-spacer></v-spacer>
+      <v-btn fab flat dark small color="#55c500">
         <v-icon dark>edit</v-icon>
       </v-btn>
       <v-btn fab flat dark small color="#55c500" @click="confirmDeleteArticle">
@@ -35,7 +28,6 @@ import TimeAgo from "vue2-timeago";
 import marked from "marked";
 import hljs from "highlight.js";
 import Router from "../router/router";
-
 const headers = {
   headers: {
     Authorization: "Bearer",
@@ -45,7 +37,6 @@ const headers = {
     uid: localStorage.getItem("uid")
   }
 };
-
 @Component({
   components: {
     TimeAgo
@@ -56,20 +47,18 @@ export default class ArticleContainer extends Vue {
   async mounted(): Promise<void> {
     await this.fetchArticle(this.$route.params.id);
   }
-
   async created(): Promise<void> {
     const renderer = new marked.Renderer();
-     let data = "";
-     renderer.code = function(code, lang) {
-       const _lang = lang.split(".").pop();
+    let data = "";
+    renderer.code = function(code, lang) {
+      const _lang = lang.split(".").pop();
       try {
         data = hljs.highlight(_lang, code, true).value;
       } catch (e) {
         data = hljs.highlightAuto(code).value;
-       }
+      }
       return `<pre><code class="hljs"> ${data} </code></pre>`;
     };
-
     marked.setOptions({
       renderer: renderer,
       tables: true,
@@ -77,17 +66,14 @@ export default class ArticleContainer extends Vue {
       langPrefix: ""
     });
   }
-
   get compiledMarkdown() {
     return function(text: string) {
       return marked(text);
     };
   }
-
   get editable(): boolean {
     return localStorage.getItem("uid") === this.article.user.email;
   }
-
   async fetchArticle(id: string): Promise<void> {
     await axios
       .get(`/api/v1/articles/${id}`)
@@ -99,18 +85,16 @@ export default class ArticleContainer extends Vue {
         alert(e.response.statusText);
       });
   }
-  
   moveToEditArticlePage(id: string): void {
     Router.push(`/articles/${id}/edit`);
   }
-
   async confirmDeleteArticle(): Promise<void> {
-    const result = confirm("この記事を削除してもよろしいですか？")
+    const result = confirm("この記事を削除してもよろしいですか？");
     if (result) {
       await axios
         .delete(`/api/v1/articles/${this.article.id}`, headers)
         .then(_response => {
-          Router.push("/")
+          Router.push("/");
         })
         .catch(e => {
           // TODO: 適切な Error 表示
@@ -142,5 +126,4 @@ export default class ArticleContainer extends Vue {
 .user-name {
   margin-right: 1em;
 }
-
-</style> 
+</style>

--- a/app/javascript/packs/container/Header.vue
+++ b/app/javascript/packs/container/Header.vue
@@ -3,18 +3,23 @@
     <router-link to="/" class="header-link">
       <v-toolbar-title class="white--text font-weight-bold">Qiita</v-toolbar-title>
     </router-link>
-
-    <!-- <v-btn icon>
-      <v-icon>search</v-icon>
-    </v-btn>-->
-
     <v-spacer></v-spacer>
-
     <div v-if="isLoggedIn">
       <router-link to="/articles/new" class="header-link">
         <v-btn flat class="post font-weight-bold">投稿する</v-btn>
       </router-link>
-      <v-btn flat @click="logout" class="white--text font-weight-bold">ログアウト</v-btn>
+      <v-menu bottom left min-width="120">
+        <template v-slot:activator="{ on }">
+          <v-btn dark icon v-on="on">
+            <v-icon>more_vert</v-icon>
+          </v-btn>
+        </template>
+        <v-list>
+          <v-list-tile v-for="(menu, i) in menus" :key="i" @click="undefined">
+            <v-list-tile-title @click="menu.click">{{ menu.title }}</v-list-tile-title>
+          </v-list-tile>
+        </v-list>
+      </v-menu>
     </div>
     <div v-else>
       <router-link to="/sign_up" class="header-link">
@@ -26,7 +31,6 @@
     </div>
   </v-toolbar>
 </template>
-
 <script lang="ts">
 import axios from "axios";
 import { Vue, Component } from "vue-property-decorator";
@@ -43,6 +47,32 @@ const headers = {
 @Component
 export default class Header extends Vue {
   isLoggedIn: boolean = !!localStorage.getItem("access-token");
+  items: any = [
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" },
+    { title: "Menu" }
+  ];
+  menus: any = [
+    {
+      title: "マイページ",
+      click: () => {
+        this.moveToMyPage();
+      }
+    },
+    {
+      title: "下書き一覧",
+      click: () => {
+        this.moveToDrafts();
+      }
+    },
+    {
+      title: "ログアウト",
+      click: () => {
+        this.logout();
+      }
+    }
+  ];
   async logout(): Promise<void> {
     await axios
       .delete("/api/v1/auth/sign_out", headers)
@@ -57,6 +87,13 @@ export default class Header extends Vue {
         this.refresh();
       });
   }
+  moveToMyPage(): void {
+    alert("マイページへ移動");
+    Router.push("/mypage");
+  }
+  moveToDrafts(): void {
+    Router.push("/articles/drafts");
+  }
   private refresh(): void {
     localStorage.clear();
     Router.push("/");
@@ -65,7 +102,6 @@ export default class Header extends Vue {
   }
 }
 </script>
-
 <style lang="scss" scoped>
 .header-link {
   text-decoration: none;

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -1,0 +1,84 @@
+<template>
+  <v-container class="item elevation-3 articles-container">
+    <h2>最近書いた記事</h2>
+    <v-list two-line>
+      <template v-for="(article, index) in articles">
+        <v-list-tile :key="article.title" avatar>
+          <v-list-tile-avatar>
+            <img :src="article.avatar" />
+          </v-list-tile-avatar>
+
+          <v-list-tile-content>
+            <v-list-tile-title class="article-title">
+              <router-link :to="{ name: 'article', params: { id: article.id }}">{{ article.title }}</router-link>
+            </v-list-tile-title>
+            <v-list-tile-sub-title>
+              by {{ article.user.name }}
+              <time-ago
+                :refresh="60"
+                :datetime="article.updated_at"
+                locale="en"
+                tooltip="right"
+                long
+              ></time-ago>
+            </v-list-tile-sub-title>
+          </v-list-tile-content>
+        </v-list-tile>
+        <v-divider :key="index"></v-divider>
+      </template>
+    </v-list>
+  </v-container>
+</template>
+
+<script lang="ts">
+import axios from "axios";
+import { Vue, Component } from "vue-property-decorator";
+import TimeAgo from "vue2-timeago";
+import Router from "../router/router";
+const headers = {
+  headers: {
+    Authorization: "Bearer",
+    "Access-Control-Allow-Origin": "*",
+    "access-token": localStorage.getItem("access-token"),
+    client: localStorage.getItem("client"),
+    uid: localStorage.getItem("uid")
+  }
+};
+@Component({
+  components: {
+    TimeAgo
+  }
+})
+export default class MyPageContainer extends Vue {
+  articles: string[] = [];
+  async mounted(): Promise<void> {
+    await this.fetchArticles();
+  }
+  async fetchArticles(): Promise<void> {
+    await axios.get("/api/v1/current/articles", headers).then(response => {
+      response.data.map((article: any) => {
+        this.articles.push(article);
+      });
+    });
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.articles-container {
+  margin-top: 2em;
+  .article-title {
+    a {
+      color: #000;
+      font-weight: bold;
+      text-decoration: none;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    a:visited {
+      color: #777;
+    }
+  }
+}
+</style> 

--- a/app/javascript/packs/container/MyPageContainer.vue
+++ b/app/javascript/packs/container/MyPageContainer.vue
@@ -16,11 +16,12 @@
               by {{ article.user.name }}
               <time-ago
                 :refresh="60"
-                :datetime="article.updated_at"
+                :datetime="article.created_at"
                 locale="en"
                 tooltip="right"
                 long
               ></time-ago>
+              <span>に投稿</span>
             </v-list-tile-sub-title>
           </v-list-tile-content>
         </v-list-tile>

--- a/app/javascript/packs/router/router.ts
+++ b/app/javascript/packs/router/router.ts
@@ -5,6 +5,7 @@ import ArticleContainer from "../container/ArticleContainer.vue";
 import RegisterContainer from "../container/RegisterContainer.vue";
 import LoginContainer from "../container/LoginContainer.vue";
 import EditArticleContainer from "../container/EditArticleContainer.vue";
+import MyPageContainer from "../container/MyPageContainer.vue";
 
 Vue.use(VueRouter);
 
@@ -16,6 +17,7 @@ export default new VueRouter({
     { path: "/sign_in", component: LoginContainer },
     { path: "/articles/new", component: EditArticleContainer },
     { path: "/articles/:id/edit", component: EditArticleContainer },
-    { path: "/articles/:id", component: ArticleContainer, name: "article" }
+    { path: "/articles/:id", component: ArticleContainer, name: "article" },
+    { path: "/mypage", component: MyPageContainer }
   ]
 });

--- a/app/serializers/api/v1/current/article_preview_serializer.rb
+++ b/app/serializers/api/v1/current/article_preview_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::Current::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :created_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/current/article_preview_serializer.rb
+++ b/app/serializers/api/v1/current/article_preview_serializer.rb
@@ -1,4 +1,4 @@
 class Api::V1::Current::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :created_at
-  belongs_to :user, serializer: Api::V1::UserSerializer
+  belongs_to :user, serializer: UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   get "articles/new", to: "homes#index"
   get "articles/:id/edit", to: "homes#index"
   get "articles/:id", to: "homes#index"
+  get "mypage", to: "homes#index"
 
   namespace "api", format: "json" do
     namespace "v1" do

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.length).to eq 2
-      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
+      expect(res[0].keys).to eq ["id", "title", "created_at", "user"]
       expect(response).to have_http_status(:ok)
     end
   end


### PR DESCRIPTION
## 概要
### API
- マイページ用の API / テストを実装
- 自分で書いた公開記事を公開順で並べる
- 略式で、 created_at で並べているが、実際は status が公開になったタイミングで published_at （今はこの column 自体存在しない）を更新し、その順で並べるのが正しい。
- 下書き記事についてはマイページでは表示させず、下書き記事一覧で表示。
### Front
- 自分で書いた記事を一覧できるようマイページを修正
- 記事の作成日時を表示