### PR TITLE
delete fontawesome for resolve heroku error

### DIFF
--- a/app/javascript/packs/app.ts
+++ b/app/javascript/packs/app.ts
@@ -4,7 +4,7 @@ import Header from "./container/Header.vue";
 import Vuetify from "vuetify";
 import "vuetify/dist/vuetify.min.css";
 import "highlight.js/styles/monokai.css";
-import "@fortawesome/fontawesome-free/css/all.css"
+// import "@fortawesome/fontawesome-free/css/all.css"
 
 Vue.use(Vuetify, {
   iconfont: "fa"


### PR DESCRIPTION
## 概要
fontawesomeによるエラーでherokuにpushできないため、fontawesomeを削除。